### PR TITLE
installwizard: remove deprecated gateway4 from netplan config

### DIFF
--- a/src/rp_turn/config_applicator.py
+++ b/src/rp_turn/config_applicator.py
@@ -76,9 +76,13 @@ class ConfigApplicator:
                 ],
                 "nameservers": {"addresses": utils.config_get(self._config["dns"])},
             }
+
+            # Note: Installwizard only permits routes OR gateway on an interface
             # Only add gateway if it exists
             if utils.config_get(network["gateway"]) not in [None, ""]:
-                netplan["network"]["ethernets"][nic]["gateway4"] = network["gateway"]
+                netplan["network"]["ethernets"][nic]["routes"] = [
+                    {"to": "default", "via": network["gateway"]}
+                ]
             # Only add routes if it exists
             if utils.config_get(network["routes"]) not in [None, []]:
                 netplan["network"]["ethernets"][nic]["routes"] = [

--- a/src/rp_turn/tests/test_config_applicator.py
+++ b/src/rp_turn/tests/test_config_applicator.py
@@ -68,8 +68,7 @@ VALID_CONFIGS = [
                 "nic0": {
                     "ipaddress": "10.44.4.1",
                     "netmask": "255.255.0.0",
-                    "gateway": "10.44.0.1",
-                    "routes": [],
+                    "routes": [{"to": "10.45.0.0/16", "via": "10.44.0.1"}],
                 },
                 "nic1": {
                     "ipaddress": "10.250.4.1",
@@ -112,7 +111,6 @@ VALID_CONFIGS = [
                 "nic0": {
                     "ipaddress": "10.44.4.1",
                     "netmask": "255.255.0.0",
-                    "gateway": "10.44.0.1",
                     "routes": [],
                 },
                 "nic1": {
@@ -262,7 +260,11 @@ class TestBaseNetworkSettings(TestDefaultSettings):
                     )
                 ],
             )
-            self.assertEqual(nic["gateway4"], adapter["gateway"])
+            # Installwizard only permits routes OR gateway on an interface
+            if adapter["gateway"]:
+                self.assertEqual(nic["routes"], [{"to": "default", "via": adapter["gateway"]}])
+            elif adapter["routes"]:
+                self.assertEqual(nic["routes"], adapter["routes"])
             self.assertEqual(nic["nameservers"]["addresses"], self._config["dns"])
         self.assertIn(
             self._config["hostname"],

--- a/src/rp_turn/tests/test_config_applicator.py
+++ b/src/rp_turn/tests/test_config_applicator.py
@@ -262,7 +262,9 @@ class TestBaseNetworkSettings(TestDefaultSettings):
             )
             # Installwizard only permits routes OR gateway on an interface
             if adapter["gateway"]:
-                self.assertEqual(nic["routes"], [{"to": "default", "via": adapter["gateway"]}])
+                self.assertEqual(
+                    nic["routes"], [{"to": "default", "via": adapter["gateway"]}]
+                )
             elif adapter["routes"]:
                 self.assertEqual(nic["routes"], adapter["routes"])
             self.assertEqual(nic["nameservers"]["addresses"], self._config["dns"])


### PR DESCRIPTION
Also fixes config applicator unittests to specify gateway only when the installwizard would permit it.

Fixes #40 