### PR TITLE
coturn: remove old `no-loopback-peers` config item

### DIFF
--- a/roles/apt/tasks/main.yml
+++ b/roles/apt/tasks/main.yml
@@ -5,7 +5,7 @@
   apt:
     state: present
     name:
-      - coturn
+      - coturn>=4.5.1
       - cron
       - fail2ban
       - iptables-persistent

--- a/src/rp_turn/templates/turnserver.conf
+++ b/src/rp_turn/templates/turnserver.conf
@@ -16,7 +16,6 @@ lt-cred-mech
 no-tcp-relay
 no-tls
 no-dtls
-no-loopback-peers
 no-multicast-peers
 stale-nonce
 #proc-user=turnserver


### PR DESCRIPTION
Breaking change in coturn 4.5.1.0 so enforce package version minimum.

Fixes #66